### PR TITLE
Fix #3

### DIFF
--- a/treeTable.js
+++ b/treeTable.js
@@ -194,7 +194,7 @@ var com_github_culmat_jsTreeTable =  (function(){
 			}  else {
 				td.prepend($('<span style="padding-left:16px;" /></span>'))
 			}
-			td.prepend($('<span style="padding-left:'+(15*parseInt(level-1))+'px;" /></span>'))
+			td.prepend($('<span style="padding-left:'+(15*parseInt(level))+'px;" /></span>'))
 			td.css('white-space','nowrap')
 			tr.trExpand = function(changeState){
 				if(this.trChildren.length < 1) return


### PR DESCRIPTION
The problem is that with `level - 1`, if `level=0` you get padding of `-15px` which doesn't render properly, thus you two indentations of 0px.